### PR TITLE
Move common functions in netbox/utils sub-module

### DIFF
--- a/pkg/connector/netbox/netbox_test.go
+++ b/pkg/connector/netbox/netbox_test.go
@@ -16,7 +16,6 @@ import (
 
 	bnet "github.com/bio-routing/bio-rd/net"
 	dbModel "github.com/cloudflare/octopus/pkg/connector/netbox/model"
-	nbUtils "github.com/cloudflare/octopus/pkg/connector/netbox/utils"
 	octopuspb "github.com/cloudflare/octopus/proto/octopus"
 )
 
@@ -1018,57 +1017,5 @@ func TestEnrichment(t *testing.T) {
 		}
 
 		assert.Equal(t, test.expected, test.t.ToProto(), test.name)
-	}
-}
-
-func TestExtractInterfaceAndUnit(t *testing.T) {
-	tests := []struct {
-		name            string
-		input           string
-		expectedName    string
-		expectedVLANTag model.VLANTag
-		wantFail        bool
-	}{
-		{
-			name:            "dot1q",
-			input:           "vlan.900",
-			expectedName:    "vlan",
-			expectedVLANTag: model.NewVLANTag(0, 900),
-		},
-		{
-			name:            "Q-in-Q",
-			input:           "xe-0/0/0.100.200",
-			expectedName:    "xe-0/0/0",
-			expectedVLANTag: model.NewVLANTag(100, 200),
-		},
-		{
-			name:            "broken",
-			input:           "xe-0/0/0",
-			expectedName:    "xe-0/0/0",
-			expectedVLANTag: model.NewVLANTag(100, 200),
-			wantFail:        true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			ifName, vt, err := nbUtils.ExtractInterfaceAndUnit(test.input)
-			if err != nil {
-				if test.wantFail {
-					return
-				}
-
-				t.Errorf("unexpected failure of test %q: %v", test.name, err)
-				return
-			}
-
-			if test.wantFail {
-				t.Errorf("unexpected success of test %q", test.name)
-				return
-			}
-
-			assert.Equal(t, test.expectedName, ifName, test.name)
-			assert.Equal(t, test.expectedVLANTag, vt, test.name)
-		})
 	}
 }

--- a/pkg/connector/netbox/netbox_test.go
+++ b/pkg/connector/netbox/netbox_test.go
@@ -16,6 +16,7 @@ import (
 
 	bnet "github.com/bio-routing/bio-rd/net"
 	dbModel "github.com/cloudflare/octopus/pkg/connector/netbox/model"
+	nbUtils "github.com/cloudflare/octopus/pkg/connector/netbox/utils"
 	octopuspb "github.com/cloudflare/octopus/proto/octopus"
 )
 
@@ -1051,7 +1052,7 @@ func TestExtractInterfaceAndUnit(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ifName, vt, err := extractInterfaceAndUnit(test.input)
+			ifName, vt, err := nbUtils.ExtractInterfaceAndUnit(test.input)
 			if err != nil {
 				if test.wantFail {
 					return

--- a/pkg/connector/netbox/utils/utils.go
+++ b/pkg/connector/netbox/utils/utils.go
@@ -85,7 +85,7 @@ func GetCustomFieldData(md *model.MetaData, customFieldData string) {
 
 func GetInterfaceAndVLANTag(name string) (ifName string, vt model.VLANTag, err error) {
 	if isLogicalInterface(name) {
-		return ExtractInterfaceAndUnit(name)
+		return extractInterfaceAndUnit(name)
 	}
 
 	return name, model.VLANTag{}, nil
@@ -95,7 +95,7 @@ func isLogicalInterface(name string) bool {
 	return strings.Contains(name, ".")
 }
 
-func ExtractInterfaceAndUnit(name string) (string, model.VLANTag, error) {
+func extractInterfaceAndUnit(name string) (string, model.VLANTag, error) {
 	extractedVars := reSubMatchMap(ifNameTagsRegexp, name)
 	if _, exists := extractedVars["intf_name"]; !exists {
 		return "", model.VLANTag{}, fmt.Errorf("unable to extract interface name from %q", name)

--- a/pkg/connector/netbox/utils/utils.go
+++ b/pkg/connector/netbox/utils/utils.go
@@ -1,0 +1,140 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cloudflare/octopus/pkg/model"
+)
+
+var (
+	ifNameTagsRegexp = regexp.MustCompile(`^(?P<intf_name>.+?)\.((?P<outer_tag>\d+)\.)?(?P<inner_tag>\d+)$`)
+)
+
+func ParseUnitStr(unitStr string) (model.VLANTag, error) {
+	if strings.Contains(unitStr, ".") {
+		parts := strings.Split(unitStr, ".")
+		if len(parts) != 2 {
+			return model.VLANTag{}, fmt.Errorf("invalid unit string %q", unitStr)
+		}
+
+		outerTag, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return model.VLANTag{}, fmt.Errorf("unable to convert %q to int: %v", parts[0], err)
+		}
+
+		innerTag, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return model.VLANTag{}, fmt.Errorf("unable to convert %q to int: %v", parts[1], err)
+		}
+
+		return model.NewVLANTag(uint16(outerTag), uint16(innerTag)), nil
+	}
+
+	ctag, err := strconv.Atoi(unitStr)
+	if err != nil {
+		return model.VLANTag{}, fmt.Errorf("unable to convert %q to int: %v", unitStr, err)
+	}
+
+	return model.NewVLANTag(0, uint16(ctag)), nil
+}
+
+func SanitizeIPAddress(addr string) string {
+	if strings.Contains(addr, "/") {
+		return addr
+	}
+
+	if strings.Contains(addr, ".") {
+		return addr + "/32"
+	}
+
+	return addr + "/128"
+}
+
+func GetMetaDataFromTags(tags []string) (*model.MetaData, error) {
+	ret := model.NewMetaData()
+	for _, tag := range tags {
+		parts := strings.Split(tag, "=")
+
+		// Semantic Tag
+		if len(parts) == 2 {
+			if _, exists := ret.SemanticTags[parts[0]]; exists {
+				return nil, fmt.Errorf("key %q exists already: %q vs. %q", parts[0], ret.SemanticTags[parts[0]], parts[1])
+			}
+
+			ret.SemanticTags[parts[0]] = parts[1]
+
+		} else {
+			// Regular Tag
+			ret.Tags = append(ret.Tags, tag)
+		}
+	}
+
+	return ret, nil
+}
+
+func GetCustomFieldData(md *model.MetaData, customFieldData string) {
+	if customFieldData == "" || customFieldData == "{}" {
+		return
+	}
+
+	md.CustomFieldData = customFieldData
+}
+
+func GetInterfaceAndVLANTag(name string) (ifName string, vt model.VLANTag, err error) {
+	if isLogicalInterface(name) {
+		return ExtractInterfaceAndUnit(name)
+	}
+
+	return name, model.VLANTag{}, nil
+}
+
+func isLogicalInterface(name string) bool {
+	return strings.Contains(name, ".")
+}
+
+func ExtractInterfaceAndUnit(name string) (string, model.VLANTag, error) {
+	extractedVars := reSubMatchMap(ifNameTagsRegexp, name)
+	if _, exists := extractedVars["intf_name"]; !exists {
+		return "", model.VLANTag{}, fmt.Errorf("unable to extract interface name from %q", name)
+	}
+
+	if _, exists := extractedVars["inner_tag"]; !exists {
+		return "", model.VLANTag{}, fmt.Errorf("unable to extract inner tag from %q", name)
+	}
+
+	innerTag, err := strconv.Atoi(extractedVars["inner_tag"])
+	if err != nil {
+		return "", model.VLANTag{}, fmt.Errorf("unable to convert inner tag from string %q to int (%q)", extractedVars["inner_tag"], name)
+	}
+
+	vt := model.VLANTag{
+		InnerTag: uint16(innerTag),
+	}
+
+	outerTagStr := extractedVars["outer_tag"]
+	if outerTagStr != "" {
+		outerTag, err := strconv.Atoi(outerTagStr)
+		if err != nil {
+			return "", model.VLANTag{}, fmt.Errorf("unable to convert outer tag from string %q to int (%q)", outerTagStr, name)
+		}
+
+		vt.OuterTag = uint16(outerTag)
+	}
+
+	return extractedVars["intf_name"], vt, nil
+}
+
+func reSubMatchMap(r *regexp.Regexp, str string) map[string]string {
+	match := r.FindStringSubmatch(str)
+	subMatchMap := make(map[string]string)
+	for i, name := range r.SubexpNames() {
+		if i != 0 && name != "" && i <= len(match) {
+			subMatchMap[name] = match[i]
+		}
+	}
+
+	return subMatchMap
+}

--- a/pkg/connector/netbox/utils/utils_test.go
+++ b/pkg/connector/netbox/utils/utils_test.go
@@ -1,0 +1,170 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/cloudflare/octopus/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnrichment(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantFail bool
+		expected model.VLANTag
+	}{
+		/*
+		 * Errors
+		 */
+		{
+			name:     "invalid unit string",
+			input:    "a.b.c",
+			wantFail: true,
+			expected: model.VLANTag{},
+		},
+		{
+			name:     "invalid outer tag",
+			input:    "a.1",
+			wantFail: true,
+			expected: model.VLANTag{},
+		},
+		{
+			name:     "invalid inner tag",
+			input:    "1.a",
+			wantFail: true,
+			expected: model.VLANTag{},
+		},
+		{
+			name:     "invalid single tag",
+			input:    "something",
+			wantFail: true,
+			expected: model.VLANTag{},
+		},
+		{
+			name:     "valid single tag",
+			input:    "42",
+			wantFail: false,
+			expected: model.NewVLANTag(0, 42),
+		},
+		{
+			name:     "valid double tag",
+			input:    "23.42",
+			wantFail: false,
+			expected: model.NewVLANTag(23, 42),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			vt, err := ParseUnitStr(test.input)
+			if err != nil {
+				if test.wantFail {
+					return
+				}
+
+				t.Errorf("unexpected failure of test %q: %v", test.name, err)
+				return
+			}
+
+			if test.wantFail {
+				t.Errorf("unexpected success of test %q", test.name)
+				return
+			}
+
+			assert.Equal(t, test.expected, vt, test.name)
+		})
+	}
+}
+
+func TestSanitizeIPAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "address w/ prefix-length",
+			input:    "192.0.2.42/24",
+			expected: "192.0.2.42/24",
+		},
+		{
+			name:     "IPv4 address w/o prefix-length",
+			input:    "192.0.2.42",
+			expected: "192.0.2.42/32",
+		},
+		{
+			name:     "IPv6 address w/o prefix-length",
+			input:    "2001:db8::42",
+			expected: "2001:db8::42/128",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, SanitizeIPAddress(test.input), test.name)
+		})
+	}
+}
+
+func TestExtractInterfaceAndUnit(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		expectedName    string
+		expectedVLANTag model.VLANTag
+		wantFail        bool
+	}{
+		{
+			name:            "dot1q",
+			input:           "vlan.900",
+			expectedName:    "vlan",
+			expectedVLANTag: model.NewVLANTag(0, 900),
+		},
+		{
+			name:            "Q-in-Q",
+			input:           "xe-0/0/0.100.200",
+			expectedName:    "xe-0/0/0",
+			expectedVLANTag: model.NewVLANTag(100, 200),
+		},
+		{
+			name:            "no unit",
+			input:           "xe-0/0/0",
+			expectedName:    "",
+			expectedVLANTag: model.NewVLANTag(0, 0),
+			wantFail:        true,
+		},
+		{
+			name:            "invalid qot1q",
+			input:           "xe-0/0/0.a",
+			expectedName:    "",
+			expectedVLANTag: model.NewVLANTag(0, 0),
+			wantFail:        true,
+		},
+		{
+			name:            "invalid qot1q",
+			input:           "xe-0/0/0.0.a",
+			expectedName:    "",
+			expectedVLANTag: model.NewVLANTag(0, 0),
+			wantFail:        true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ifName, vt, err := extractInterfaceAndUnit(test.input)
+			if err != nil && !test.wantFail {
+				t.Errorf("unexpected failure of test %q: %v", test.name, err)
+				return
+			}
+
+			if err == nil && test.wantFail {
+				t.Errorf("unexpected success of test %q", test.name)
+				return
+			}
+
+			assert.Equal(t, test.expectedName, ifName, test.name)
+			assert.Equal(t, test.expectedVLANTag, vt, test.name)
+		})
+	}
+}


### PR DESCRIPTION
  This is done in preparation for splitting up the NetBox connector and client
  to support version specific NetBox clients and to support multiple version of
  NetBox at the same time.